### PR TITLE
sửa đổi hàm count thành Specific Count và sửa đổi những chỗ tìm ngày …

### DIFF
--- a/StockWizard.iml
+++ b/StockWizard.iml
@@ -43,5 +43,6 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="library" name="lib" level="project" />
   </component>
 </module>

--- a/src/app/controller/SelectSceneController.java
+++ b/src/app/controller/SelectSceneController.java
@@ -59,6 +59,8 @@ public class SelectSceneController implements Initializable {
             modules.add(new Liquidity());
             modules.add(new SumHNXandHSX());
             modules.add(new SumLiquidity());
+            modules.add(new CountUpAndDownInHSX());
+            modules.add(new CountUpAndDowninUPCOM());
            // modules.add(new CountExisting());
             modules.add(new CandleStickVN30());
             modules.add(new DifferencePercent());

--- a/src/modules/CountUpAndDown.java
+++ b/src/modules/CountUpAndDown.java
@@ -4,6 +4,7 @@ import data.Data;
 import data.Session;
 import data.StockExchange;
 import utilities.Counter;
+import utilities.SpecificCount;
 
 import java.util.*;
 
@@ -18,31 +19,57 @@ public class CountUpAndDown extends SentenceGenerator{
     private Session[] sessions;
     @Override
     public String example() {
-        return "Toàn thị trường hiện đang có 77 mã tăng giá, 33 mã giảm giá và 11 mã đứng giá.";
+        return " Trên sàn HNX đang có 77 mã tăng giá, 33 mã giảm giá và 11 mã đứng giá.";
     }
 
     @Override
     public String generate() {
-        Counter counter = new Counter();
-        int[] countHNX = counter.count(data[0].getSessions());
-        int[] countHSX = counter.count(data[1].getSessions());
-        int[] countUPCOM = counter.count(data[2].getSessions());
-        
-        System.out.print(countHNX);
-        System.out.print(countHSX);
-        System.out.print(countUPCOM);
+        SpecificCount countHNX = new SpecificCount();
+        Map<String, Float> resultMapUp = new HashMap<>();
+        Map<String, Float> resultMapDown = new HashMap<>();
+        Map<String, Float> resultMapNotChange = new HashMap<>();
+        Map<String, Float> resultMapNotTrade = new HashMap<>();
 
-        int[] count = new int[3];
-        for(int i = 0; i < 3; i++){
-            count[i] = countHNX[i] + countHSX[i] + countUPCOM[i];
-        }
+        countHNX.count(data[0].getSessions());
+        resultMapUp=countHNX.getResultMapUp();
+        resultMapDown=countHNX.getResultMapDown();
+        resultMapNotChange=countHNX.getResultMapNotChange();
+        resultMapNotTrade=countHNX.getResultMapNotTrade();
 
         String[] result = new String[3];
-        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", count[0], count[1], count[2]);
-        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", count[0], count[1], count[2]);
-        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", count[0], count[1], count[2]);
+        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(),resultMapNotChange.size());
+        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
+        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
         Random r = new Random();
         return result[r.nextInt(3)];
+
+
     }
+
+    //    @Override
+//    public String generate() {
+//        Counter counter = new Counter();
+//        int[] countHNX = counter.count(data[0].getSessions());
+//        int[] countHSX = counter.count(data[1].getSessions());
+//        int[] countUPCOM = counter.count(data[2].getSessions());
+//
+//        System.out.print(countHNX);
+//        System.out.print(countHSX);
+//        System.out.print(countUPCOM);
+//
+//        int[] count = new int[3];
+//        for(int i = 0; i < 3; i++){
+//            count[i] = countHNX[i] + countHSX[i] + countUPCOM[i];
+//        }
+//
+//        String[] result = new String[3];
+//        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", count[0], count[1], count[2]);
+//        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", count[0], count[1], count[2]);
+//        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", count[0], count[1], count[2]);
+//        Random r = new Random();
+//        return result[r.nextInt(3)];
+//    }
+
+
 
 }

--- a/src/modules/CountUpAndDownInHSX.java
+++ b/src/modules/CountUpAndDownInHSX.java
@@ -1,0 +1,41 @@
+package modules;
+
+import data.Data;
+import data.Session;
+import data.StockExchange;
+import utilities.Counter;
+import utilities.SpecificCount;
+
+import java.util.*;
+public class CountUpAndDownInHSX extends SentenceGenerator{
+    private Session[] sessions;
+    @Override
+    public String example() {
+        return " Trên sàn HSX đang có 77 mã tăng giá, 33 mã giảm giá và 11 mã đứng giá.";
+    }
+
+    @Override
+    public String generate() {
+        SpecificCount countHSX = new SpecificCount();
+        Map<String, Float> resultMapUp = new HashMap<>();
+        Map<String, Float> resultMapDown = new HashMap<>();
+        Map<String, Float> resultMapNotChange = new HashMap<>();
+        Map<String, Float> resultMapNotTrade = new HashMap<>();
+
+        countHSX.count(data[1].getSessions());
+        resultMapUp=countHSX.getResultMapUp();
+        resultMapDown=countHSX.getResultMapDown();
+        resultMapNotChange=countHSX.getResultMapNotChange();
+        resultMapNotTrade=countHSX.getResultMapNotTrade();
+
+        String[] result = new String[3];
+        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(),resultMapNotChange.size());
+        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
+        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
+        Random r = new Random();
+        return result[r.nextInt(3)];
+
+
+    }
+
+}

--- a/src/modules/CountUpAndDowninUPCOM.java
+++ b/src/modules/CountUpAndDowninUPCOM.java
@@ -1,0 +1,41 @@
+package modules;
+
+import data.Data;
+import data.Session;
+import data.StockExchange;
+import utilities.Counter;
+import utilities.SpecificCount;
+
+import java.util.*;
+
+public class CountUpAndDowninUPCOM extends SentenceGenerator{
+    private Session[] sessions;
+    @Override
+    public String example() {
+        return " Trên sàn UPCOM đang có 77 mã tăng giá, 33 mã giảm giá và 11 mã đứng giá.";
+    }
+
+    @Override
+    public String generate() {
+        SpecificCount countUPCOM = new SpecificCount();
+        Map<String, Float> resultMapUp = new HashMap<>();
+        Map<String, Float> resultMapDown = new HashMap<>();
+        Map<String, Float> resultMapNotChange = new HashMap<>();
+        Map<String, Float> resultMapNotTrade = new HashMap<>();
+
+        countUPCOM.count(data[1].getSessions());
+        resultMapUp=countUPCOM.getResultMapUp();
+        resultMapDown=countUPCOM.getResultMapDown();
+        resultMapNotChange=countUPCOM.getResultMapNotChange();
+        resultMapNotTrade=countUPCOM.getResultMapNotTrade();
+
+        String[] result = new String[3];
+        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(),resultMapNotChange.size());
+        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
+        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(), resultMapNotChange.size());
+        Random r = new Random();
+        return result[r.nextInt(3)];
+
+
+    }
+}

--- a/src/modules/DifferencePercent.java
+++ b/src/modules/DifferencePercent.java
@@ -4,6 +4,7 @@ import data.Data;
 import data.Session;
 import data.StockExchange;
 import utilities.Dictionary;
+import utilities.SpecificCount;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -28,18 +29,21 @@ public class DifferencePercent extends SentenceGenerator {
         // Duyệt trên cả 3 sàn, tìm ra mã có phần trăm tăng cao nhất và mã có phần trăm giảm cao nhất
         for(int i = 0; i < 3; i++) {
             Map<String, Float> map = new HashMap<>();
-
+            SpecificCount countDay= new SpecificCount();
             Session[] sessions = data[i].getSessions();
-            Date today = sessions[0].getDate();
-            Date previousDay = null; // Ngày giao dịch trước đó
 
-            // Tìm previousDay
-            for (Session s : sessions) {
-                if (!s.getDate().equals(today)) {
-                    previousDay = s.getDate();
-                    break;
-                }
-            }
+            Date today = countDay.FindToday(data[0].getSessions());
+            Date previousDay = countDay.FindPreDay(data[0].getSessions());
+//            Date today = sessions[0].getDate();
+//            Date previousDay = null; // Ngày giao dịch trước đó
+//
+//            // Tìm previousDay
+//            for (Session s : sessions) {
+//                if (!s.getDate().equals(today)) {
+//                    previousDay = s.getDate();
+//                    break;
+//                }
+//            }
 
             for (Session s : sessions) {
                 String ticker = s.getTicker();

--- a/src/modules/GroupDepreciation.java
+++ b/src/modules/GroupDepreciation.java
@@ -4,6 +4,7 @@ import data.Input;
 import data.Session;
 import utilities.Dictionary;
 import utilities.Filter;
+import utilities.SpecificCount;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -36,16 +37,20 @@ public class GroupDepreciation extends SentenceGenerator{
         float percentReduction1 = 0, percentReduction2 = 0;
         Map<String, Float> map = new HashMap<>();
 
-        Date today = sessions[0].getDate();
-        Date previousDay = null; // Ngày giao dịch trước đó
+        SpecificCount countDay= new SpecificCount();
+        Date today = countDay.FindToday(data[0].getSessions());
+        Date previousDay = countDay.FindPreDay(data[0].getSessions());
 
-        // Tìm previousDay
-        for (Session s : sessions){
-            if (!s.getDate().equals(today)){
-                previousDay = s.getDate();
-                break;
-            }
-        }
+//        Date today = sessions[0].getDate();
+//        Date previousDay = null; // Ngày giao dịch trước đó
+//
+//        // Tìm previousDay
+//        for (Session s : sessions){
+//            if (!s.getDate().equals(today)){
+//                previousDay = s.getDate();
+//                break;
+//            }
+//        }
 
         // Tìm danh sách những mã giảm
         for (Session s : sessions) {

--- a/src/modules/MaxIncreasePercent.java
+++ b/src/modules/MaxIncreasePercent.java
@@ -4,6 +4,7 @@ import data.Data;
 import data.Session;
 import data.StockExchange;
 import utilities.Dictionary;
+import utilities.SpecificCount;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -27,16 +28,19 @@ public class MaxIncreasePercent extends SentenceGenerator{
             Map<String, Float> map = new HashMap<>();
 
             Session[] sessions = data[i].getSessions();
-            Date today = sessions[0].getDate();
-            Date previousDay = null; // Ngày giao dịch trước đó
-
-            // Tìm previousDay
-            for (Session s : sessions){
-                if (!s.getDate().equals(today)){
-                    previousDay = s.getDate();
-                    break;
-                }
-            }
+            SpecificCount countDay= new SpecificCount();
+            Date today = countDay.FindToday(data[0].getSessions());
+            Date previousDay = countDay.FindPreDay(data[0].getSessions());
+//            Date today = sessions[0].getDate();
+//            Date previousDay = null; // Ngày giao dịch trước đó
+//
+//            // Tìm previousDay
+//            for (Session s : sessions){
+//                if (!s.getDate().equals(today)){
+//                    previousDay = s.getDate();
+//                    break;
+//                }
+//            }
 
             for (Session s : sessions) {
                 String ticker = s.getTicker();

--- a/src/modules/PriceFloor.java
+++ b/src/modules/PriceFloor.java
@@ -2,6 +2,7 @@ package modules;
 
 import data.Session;
 import utilities.Dictionary;
+import utilities.SpecificCount;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -24,15 +25,9 @@ public class PriceFloor extends SentenceGenerator {
         Map<String, Float> map = new HashMap<>();
 
         Session[] sessions = data[0].getSessions();
-        Date today = sessions[0].getDate();
-        Date previousDay = null;
-
-        for (Session s : sessions) {
-            if (!s.getDate().equals(today)) {
-                previousDay = s.getDate();
-                break;
-            }
-        }
+        SpecificCount countDay= new SpecificCount();
+        Date today = countDay.FindToday(data[0].getSessions());
+        Date previousDay = countDay.FindPreDay(data[0].getSessions());
 
         for (Session s : sessions) {
             String ticker = s.getTicker();

--- a/src/modules/PriceFloorCeilinginHNX.java
+++ b/src/modules/PriceFloorCeilinginHNX.java
@@ -1,0 +1,30 @@
+//package modules;
+//
+//import data.Data;
+//import data.Input;
+//import data.Session;
+//import data.StockExchange;
+//import utilities.Counter;
+//import utilities.SpecificCount;
+//
+//import java.util.*;
+//
+//public class PriceFloorCeilinginHNX extends SentenceGenerator {
+//    @Override
+//    public String example() {
+//        return "Hôm nay sàn HNX có 30 mã giảm sàn 20 mã tăng trần";
+//    }
+//
+//    @Override
+//    public String generate() {
+//        SpecificCount counter = new SpecificCount();
+//        counter.count(data[0].getSessions());
+//        Map<String, Float> resultUp = new HashMap<>();
+//        resultUp= counter.getResultMapUp();
+//        Map<String, Float> resultDown = new HashMap<>();
+//        resultDown= counter.getResultMapDown();
+//
+//
+//    }
+//
+//}

--- a/src/modules/SumLiquidity.java
+++ b/src/modules/SumLiquidity.java
@@ -1,6 +1,8 @@
 package modules;
 
 import data.Session;
+import utilities.SpecificCount;
+
 import java.util.Date;
 
 public class SumLiquidity extends SentenceGenerator {
@@ -18,15 +20,9 @@ public class SumLiquidity extends SentenceGenerator {
         for (int i = 0; i < 3; i++) {
 
             Session[] sessions = data[i].getSessions();
-            Date today = sessions[0].getDate();
-            Date previousDay = null;
-
-            for (Session s : sessions) {
-                if (!s.getDate().equals(today)) {
-                    previousDay = s.getDate();
-                    break;
-                }
-            }
+            SpecificCount countDay= new SpecificCount();
+            Date today = countDay.FindToday(data[0].getSessions());
+            Date previousDay = countDay.FindPreDay(data[0].getSessions());
 
             for (Session s : sessions) {
                 

--- a/src/modules/SummaryAAV.java
+++ b/src/modules/SummaryAAV.java
@@ -72,7 +72,7 @@ public class SummaryAAV extends SentenceGenerator {
     }
 
     public static void main(String[] args) {
-        Input.updateDataFromLocal("res/sample/data/CafeF.SolieuGD.Upto27042020.zip");
+        Input.updateDataFromLocal("Downloads\\CafeF.SolieuGD.Upto11062020.zip");
         System.out.println(new SummaryAAV().generate());
     }
 }

--- a/src/modules/UpDownAndNotTrade.java
+++ b/src/modules/UpDownAndNotTrade.java
@@ -1,38 +1,68 @@
 package modules;
 
+import data.Session;
 import utilities.Counter;
+import utilities.SpecificCount;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 public class UpDownAndNotTrade extends SentenceGenerator {
-
+    private Session[] sessions;
     @Override
     public String example() {
-        return "Hiện có 153 mã tăng giá, 10 mã giảm giá và 3 mã chưa có giao dịch.";
+        return " Trên sàn HNX đang có 77 mã tăng giá, 33 mã giảm giá và 11 mã đứng giá.";
     }
 
     @Override
     public String generate() {
-        Counter counter = new Counter();
-        int[] countHNX = counter.count(data[0].getSessions());
-        int[] countHSX = counter.count(data[1].getSessions());
-        int[] countUPCOM = counter.count(data[2].getSessions());
+        SpecificCount countHNX = new SpecificCount();
+        Map<String, Float> resultMapUp = new HashMap<>();
+        Map<String, Float> resultMapDown = new HashMap<>();
+        Map<String, Float> resultMapNotChange = new HashMap<>();
+        Map<String, Float> resultMapNotTrade = new HashMap<>();
 
-        int[] count = new int[4];
-        for(int i = 0; i < 4; i++){
+        countHNX.count(data[0].getSessions());
+        resultMapUp=countHNX.getResultMapUp();
+        resultMapDown=countHNX.getResultMapDown();
+        resultMapNotChange=countHNX.getResultMapNotChange();
+        resultMapNotTrade=countHNX.getResultMapNotTrade();
 
-//        System.out.println(countHNX[0]);
-//        System.out.println(countHSX[0]);
-//        System.out.println(countUPCOM[0]);
-//        int[] count = new int[3];
-//        for(int i = 0; i < 3; i++){
+        String[] result = new String[3];
+        result[0] = String.format("Toàn thị trường hiện đang có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(),resultMapNotTrade.size());
+        result[1] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá trên toàn thị trường", resultMapUp.size(), resultMapDown.size(), resultMapNotTrade.size());
+        result[2] = String.format("Đến thời điểm này, toàn thị trường có %d mã tăng giá, %d mã giảm giá và %d mã đứng giá", resultMapUp.size(), resultMapDown.size(), resultMapNotTrade.size());
+        Random r = new Random();
+        return result[r.nextInt(3)];
 
-            count[i] = countHNX[i] + countHSX[i] + countUPCOM[i];
-        }
-        String[] ret = new String[3];
-        ret[0] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã chưa có giao dịch.", count[0], count[1], count[3]);
-        ret[1] = String.format("Toàn thị trường có %d mã tăng, %d mã giảm và %d mã không giao dịch", count[0], count[1], count[3]);
-        ret[2] = String.format("Số mã tăng: %d mã, số mã giảm: %d mã, số mã không giao dịch: %d mã", count[0], count[1], count[3]);
-        return ret[new Random().nextInt(3)];
-    }
+//    @Override
+//    public String example() {
+//        return "Hiện có 153 mã tăng giá, 10 mã giảm giá và 3 mã chưa có giao dịch.";
+//    }
+//
+//    @Override
+//    public String generate() {
+//        Counter counter = new Counter();
+//        int[] countHNX = counter.count(data[0].getSessions());
+//        int[] countHSX = counter.count(data[1].getSessions());
+//        int[] countUPCOM = counter.count(data[2].getSessions());
+//
+//        int[] count = new int[4];
+//        for(int i = 0; i < 4; i++){
+//
+////        System.out.println(countHNX[0]);
+////        System.out.println(countHSX[0]);
+////        System.out.println(countUPCOM[0]);
+////        int[] count = new int[3];
+////        for(int i = 0; i < 3; i++){
+//
+//            count[i] = countHNX[i] + countHSX[i] + countUPCOM[i];
+//        }
+//        String[] ret = new String[3];
+//        ret[0] = String.format("Hiện có %d mã tăng giá, %d mã giảm giá và %d mã chưa có giao dịch.", count[0], count[1], count[3]);
+//        ret[1] = String.format("Toàn thị trường có %d mã tăng, %d mã giảm và %d mã không giao dịch", count[0], count[1], count[3]);
+//        ret[2] = String.format("Số mã tăng: %d mã, số mã giảm: %d mã, số mã không giao dịch: %d mã", count[0], count[1], count[3]);
+//        return ret[new Random().nextInt(3)];
+   }
 }

--- a/src/utilities/Counter.java
+++ b/src/utilities/Counter.java
@@ -52,6 +52,7 @@ public class Counter {
             String ticker = s.getTicker();
             if(s.getDate().equals(today)){
                 map.put(ticker, s.getClose());
+
             }
             else if (s.getDate().equals(previousDay)){
                 if (map.containsKey(ticker)) {

--- a/src/utilities/SpecificCount.java
+++ b/src/utilities/SpecificCount.java
@@ -1,0 +1,97 @@
+package utilities;
+
+import data.Session;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+  Đếm rồi lưu tên mã tăng, giảm cùng giá trị đóng cửa tương ứng vào 2 map:
+        resultMapUp: chứa tên mã tăng và giá trị đóng cửa tương ứng
+        resultMapDown: chứa tên mã giảm và giá trị đóng cửa tương ứng
+        resultMapNotChange
+        resultMapNotTrade
+ */
+
+public class SpecificCount {
+
+    private Map<String, Float> resultMapUp = new HashMap<>();
+    private Map<String, Float> resultMapDown = new HashMap<>();
+    private Map<String, Float> resultMapNotChange = new HashMap<>();
+    private Map<String, Float> resultMapNotTrade = new HashMap<>();
+
+    public Map<String, Float> getResultMapUp() {
+        return resultMapUp;
+    }
+
+    public Map<String, Float> getResultMapDown() {
+        return resultMapDown;
+    }
+
+    public Map<String, Float> getResultMapNotChange() {
+        return resultMapNotChange;
+    }
+
+    public Map<String, Float> getResultMapNotTrade() {
+        return resultMapNotTrade;
+    }
+
+    public void count(Session[] sessions) {
+        SpecificCount date= new SpecificCount();
+        Map<String, Float> map = new HashMap<>();
+
+        Date today= date.FindToday(sessions);
+        Date previousDay=date.FindPreDay(sessions);
+        System.out.println(previousDay);
+        System.out.println(today);
+
+        for (Session s : sessions) {
+            String ticker = s.getTicker();
+            if (s.getDate().equals(today)) {
+                map.put(ticker, s.getClose());
+            } else if (s.getDate().equals(previousDay)) {
+                if (map.containsKey(ticker)) {
+                    float close = s.getClose();
+                    float newClose = map.get(ticker);
+                    if (newClose - close > 0) {
+                        resultMapUp.put(ticker, newClose);
+                    }else if (newClose - close < 0) {
+                        resultMapDown.put(ticker, newClose);
+                    }else{
+                        resultMapNotChange.put(ticker, newClose);
+                    }
+                }
+                else{
+                    resultMapNotTrade.put(ticker, (float) 0);
+                }
+                } else {
+                    break;
+                }
+            }
+        }
+
+
+
+    public Date FindToday(Session[] sessions){
+        Date today  = sessions[0].getDate();
+        return today;
+    }
+    public Date FindPreDay(Session[] sessions){
+        SpecificCount date= new SpecificCount();
+        Date previousDay = null; // Ngày giao dịch trước đó
+        Date today= date.FindToday(sessions);
+        // Tìm previousDay
+        for (Session s : sessions){
+            if (!s.getDate().equals(today)){
+                previousDay = s.getDate();
+                break;
+            }
+        }
+        return previousDay;
+    }
+}
+
+
+


### PR DESCRIPTION
…hôm qua và ngày hôm nay

Em thấy hàm count chỉ đẩy ra số các mã tăng giảm... còn mã nào tăng giảm thì ko biết.
Em tạo hàm SpecificCount  nó sẽ đẩy ra 4 cái map:
     resultMapUp: chứa tên mã tăng và giá trị đóng cửa tương ứng
        resultMapDown: chứa tên mã giảm và giá trị đóng cửa tương ứng
        resultMapNotChange: lưu mã ko thay đổi giá
        resultMapNotTrade: lưu mã ko giao dịch trong ngày
- Em thấy ở các modul mn cứ phải viết lại hàm tìm ngày lên em viết luôn 2 hàm 1 tìm ngày hôm nay, 1 tìm ngày hôm trước. em để nó ở trong Specific Count. Những chỗ lặp code tìm ngày như vậy trong các modul mẫu câu của mn em đã thay đổi phù hợp với 2 hàm của em vừa viết rồi
- Cái hàm CountUpAndDown của anh em đã chuyển nó thành 3 cái mẫu câu tìm CountUpAndDown trên sàn HNX, HSX, và UPCOM. 
-hàm UpDownAndNotTrade em cx đã đổi thành UpDownAndNotTrade trên sàn HNX nhưng chưa đổi tên. anh đổi giúp em